### PR TITLE
Align side menu layout header with Animals styling

### DIFF
--- a/src/components/common/Layout.tsx
+++ b/src/components/common/Layout.tsx
@@ -9,48 +9,53 @@ interface LayoutProps {
   onBack?: () => void;
   useSideMenu?: boolean;
   currentPage?: string;
+  headerActions?: ReactNode;
 }
 
-export function Layout({ 
-  children, 
-  title, 
-  showBackButton = false, 
-  onBack, 
+export function Layout({
+  children,
+  title,
+  showBackButton = false,
+  onBack,
   useSideMenu = false,
-  currentPage 
+  currentPage,
+  headerActions
 }: LayoutProps) {
   const [showMenu, setShowMenu] = useState(false);
 
   if (useSideMenu) {
     return (
       <div className="min-h-screen bg-background">
-        {/* Header con menú hamburguesa */}
-        <header className="bg-white shadow-sm border-b border-gray-200">
-          <div className="flex items-center justify-between p-6">
-            <button 
+        <header className="sticky top-0 z-40 bg-white shadow-sm border-b border-gray-200">
+          <div className="flex items-center justify-between px-4 pt-4 pb-2">
+            <button
               onClick={() => setShowMenu(!showMenu)}
-              className="p-4 rounded-xl hover:bg-primary-50 transition-colors min-w-[60px] min-h-[60px] flex items-center justify-center"
+              className="flex h-12 w-12 items-center justify-center rounded-full bg-primary-50 text-primary-700 hover:bg-primary-100 transition-colors shadow-sm"
               aria-label="Abrir menú principal"
             >
-              <svg className="w-8 h-8 text-primary-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg className="w-7 h-7" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M4 6h16M4 12h16M4 18h16" />
               </svg>
             </button>
-            <h1 className="text-2xl font-bold text-primary-800">{title || 'MiRancho360'}</h1>
-            <div className="w-16"></div> {/* Spacer */}
+            <h1 className="flex-1 text-center text-xl font-bold text-slate-900">
+              {title || 'MiRancho360'}
+            </h1>
+            <div className="flex w-24 justify-end gap-2">
+              {headerActions ?? <div className="w-12" />}
+            </div>
           </div>
         </header>
 
-        {/* Menu lateral */}
-        <SideMenu 
-          isOpen={showMenu} 
+        <SideMenu
+          isOpen={showMenu}
           onClose={() => setShowMenu(false)}
           currentPage={currentPage}
         />
 
-        {/* Main Content */}
-        <main className="p-6">
-          {children}
+        <main className="pt-24 pb-8">
+          <div className="max-w-6xl mx-auto px-4">
+            {children}
+          </div>
         </main>
       </div>
     );

--- a/src/pages/AnimalFormPage.tsx
+++ b/src/pages/AnimalFormPage.tsx
@@ -161,21 +161,19 @@ export function AnimalFormPage() {
   if (loadingAnimal || loadingRazas || loadingSitios) {
     return (
       <div className="min-h-screen bg-background">
-        <header className="bg-white shadow-sm border-b border-gray-200">
-          <div className="flex items-center justify-between p-6">
-            <div className="flex items-center space-x-4">
-              <button
-                onClick={() => navigate('/animales')}
-                className="p-4 rounded-xl hover:bg-primary-50 transition-colors min-w-[60px] min-h-[60px] flex items-center justify-center"
-                aria-label="Volver a animales"
-              >
-                <svg className="w-8 h-8 text-primary-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M15 19l-7-7 7-7" />
-                </svg>
-              </button>
-            </div>
-            <h1 className="text-2xl font-bold text-primary-800">Cargando...</h1>
-            <div className="w-16"></div>
+        <header className="sticky top-0 z-40 bg-white shadow-sm border-b border-gray-200">
+          <div className="flex items-center justify-between px-4 pt-4 pb-2">
+            <button
+              onClick={() => navigate('/animales')}
+              className="flex h-12 w-12 items-center justify-center rounded-full bg-primary-50 text-primary-700 hover:bg-primary-100 transition-colors shadow-sm"
+              aria-label="Volver a animales"
+            >
+              <svg className="w-7 h-7" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M15 19l-7-7 7-7" />
+              </svg>
+            </button>
+            <h1 className="flex-1 text-center text-xl font-bold text-slate-900">Cargando...</h1>
+            <div className="flex w-12 justify-end" />
           </div>
         </header>
         
@@ -190,21 +188,21 @@ export function AnimalFormPage() {
   return (
     <div className="min-h-screen bg-background">
       {/* Header */}
-      <header className="bg-white shadow-sm border-b border-gray-200">
-        <div className="flex items-center justify-between p-6">
-          <button 
+      <header className="sticky top-0 z-40 bg-white shadow-sm border-b border-gray-200">
+        <div className="flex items-center justify-between px-4 pt-4 pb-2">
+          <button
             onClick={() => setShowMenu(!showMenu)}
-            className="p-4 rounded-xl hover:bg-primary-50 transition-colors min-w-[60px] min-h-[60px] flex items-center justify-center"
+            className="flex h-12 w-12 items-center justify-center rounded-full bg-primary-50 text-primary-700 hover:bg-primary-100 transition-colors shadow-sm"
             aria-label="Abrir menú principal"
           >
-            <svg className="w-8 h-8 text-primary-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg className="w-7 h-7" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M4 6h16M4 12h16M4 18h16" />
             </svg>
           </button>
-          <h1 className="text-2xl font-bold text-primary-800">
+          <h1 className="flex-1 text-center text-xl font-bold text-slate-900">
             {isEditing ? 'Editar Animal' : 'Nuevo Animal'}
           </h1>
-          <div className="w-16"></div>
+          <div className="flex w-12 justify-end" />
         </div>
       </header>
 

--- a/src/pages/AnimalProfilePage.tsx
+++ b/src/pages/AnimalProfilePage.tsx
@@ -143,28 +143,28 @@ export function AnimalProfilePage() {
   return (
     <div className="fixed inset-0 bg-background z-50 animate-slide-in-from-right overflow-y-auto">
       {/* Header fijo con botones de acción */}
-      <header className="sticky top-0 bg-white shadow-md z-10 border-b border-gray-200">
-        <div className="flex items-center justify-between p-4">
+      <header className="sticky top-0 z-40 bg-white shadow-sm border-b border-gray-200">
+        <div className="flex items-center justify-between px-4 pt-4 pb-2">
           <button
             onClick={handleGoBack}
-            className="p-3 rounded-xl hover:bg-gray-100 transition-colors"
+            className="flex h-12 w-12 items-center justify-center rounded-full text-slate-900 hover:bg-gray-100 transition-colors"
             aria-label="Volver a la lista"
           >
-            <svg className="w-6 h-6 text-gray-900" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M15 19l-7-7 7-7" />
             </svg>
           </button>
-          
-          <h1 className="text-xl font-bold text-gray-900 truncate max-w-[60%]">
+
+          <h1 className="flex-1 text-center text-xl font-bold text-slate-900 truncate px-4">
             {animal.arete} - {animal.nombre || 'Sin nombre'}
           </h1>
-          
+
           <button
             onClick={handleEdit}
-            className="p-3 rounded-xl hover:bg-primary-100 transition-colors"
+            className="flex h-12 w-12 items-center justify-center rounded-full text-primary-700 hover:bg-primary-100 transition-colors"
             aria-label="Editar animal"
           >
-            <Icon name="pencil" className="w-6 h-6 text-primary-600" />
+            <Icon name="pencil" className="w-6 h-6" />
           </button>
         </div>
       </header>

--- a/src/pages/AnimalsListPage.tsx
+++ b/src/pages/AnimalsListPage.tsx
@@ -58,6 +58,7 @@ export function AnimalsListPage() {
   const [showSearchInput, setShowSearchInput] = useState(true);
   const [showMenu, setShowMenu] = useState(false);
   const [showAllFilters, setShowAllFilters] = useState(false);
+  const [isKeyboardVisible, setIsKeyboardVisible] = useState(false);
   
   // Auto-mostrar búsqueda si hay texto
   useEffect(() => {
@@ -82,6 +83,32 @@ export function AnimalsListPage() {
       setShowAllFilters(true);
     }
   }, [filters.raza, filters.estado, showAllFilters]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !('visualViewport' in window)) {
+      return;
+    }
+
+    const viewport = window.visualViewport;
+    if (!viewport) {
+      return;
+    }
+
+    const handleViewportChange = () => {
+      const heightDifference = window.innerHeight - viewport.height;
+      setIsKeyboardVisible(heightDifference > 150);
+    };
+
+    viewport.addEventListener('resize', handleViewportChange);
+    viewport.addEventListener('scroll', handleViewportChange);
+
+    handleViewportChange();
+
+    return () => {
+      viewport.removeEventListener('resize', handleViewportChange);
+      viewport.removeEventListener('scroll', handleViewportChange);
+    };
+  }, []);
   
 
 
@@ -255,13 +282,15 @@ export function AnimalsListPage() {
         <div className="fixed top-16 left-0 right-0 z-30 p-4 bg-white border-b border-gray-100">
           <div className="relative flex w-full items-center">
             <Icon name="search" className="absolute left-4 w-5 h-5 text-slate-500" />
-            <input 
+            <input
               ref={searchInputRef}
-              className="w-full rounded-full border border-gray-200 bg-gray-50 py-3 pl-12 pr-10 text-base text-slate-900 placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-primary-400 focus:bg-white focus:border-primary-300" 
-              placeholder="Buscar por arete, nombre, raza..." 
+              className="w-full rounded-full border border-gray-200 bg-gray-50 py-3 pl-12 pr-10 text-base text-slate-900 placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-primary-400 focus:bg-white focus:border-primary-300"
+              placeholder="Buscar por arete, nombre, raza..."
               type="text"
               value={filters.search}
               onChange={(e) => setFilters({ ...filters, search: e.target.value })}
+              onFocus={() => setIsKeyboardVisible(true)}
+              onBlur={() => setIsKeyboardVisible(false)}
             />
             <button
               onClick={() => {
@@ -279,119 +308,123 @@ export function AnimalsListPage() {
       {/* Contenido principal con padding para header fijo */}
       <div className={`${showSearchInput ? 'pt-40' : 'pt-20'}`}>
         {/* Filtros desplegables modernos */}
-        <div className="px-4 pb-4 relative z-10">
-        {/* Filtros organizados verticalmente */}
-        <div className="space-y-3 mb-3">
-          {/* Filtro de Sitios/Lugares - Ancho completo, siempre visible */}
-          <div className="flex items-center gap-3">
-            <Icon name="home" className="w-5 h-5 text-gray-600 flex-shrink-0" />
-            <select
-              value={filters.sitio}
-              onChange={(e) => setFilters({ ...filters, sitio: e.target.value })}
-              className={`flex-1 rounded-xl px-4 py-3 text-base font-medium border-2 transition-colors ${
-                filters.sitio 
-                  ? 'bg-primary-100 text-primary-800 border-primary-300' 
-                  : 'bg-gray-50 text-gray-700 border-gray-200 hover:bg-gray-100'
-              }`}
-            >
-              <option value="">Todas las Parcelas/Sitios</option>
-              {uniqueSitios.map(sitio => (
-                <option key={sitio} value={sitio}>{sitio}</option>
-              ))}
-            </select>
-          </div>
-          
-          {/* Filtros adicionales - Raza y Estado lado a lado cuando se activan */}
-          {showAllFilters && (
-            <div className="grid grid-cols-2 gap-3 animate-in slide-in-from-top duration-200">
-              {/* Filtro de Razas - Media anchura */}
-              <div className="flex items-center gap-2">
-                <Icon name="cow-large" className="w-4 h-4 text-gray-600 flex-shrink-0" />
+        {!isKeyboardVisible && (
+          <div className="px-4 pb-4 relative z-10">
+            {/* Filtros organizados verticalmente */}
+            <div className="space-y-3 mb-3">
+              {/* Filtro de Sitios/Lugares - Ancho completo, siempre visible */}
+              <div className="flex items-center gap-3">
+                <Icon name="home" className="w-5 h-5 text-gray-600 flex-shrink-0" />
                 <select
-                  value={filters.raza}
-                  onChange={(e) => setFilters({ ...filters, raza: e.target.value })}
-                  className={`flex-1 rounded-xl px-3 py-3 text-base font-medium border-2 transition-colors ${
-                    filters.raza 
-                      ? 'bg-primary-100 text-primary-800 border-primary-300' 
+                  value={filters.sitio}
+                  onChange={(e) => setFilters({ ...filters, sitio: e.target.value })}
+                  className={`flex-1 rounded-xl px-4 py-3 text-base font-medium border-2 transition-colors ${
+                    filters.sitio
+                      ? 'bg-primary-100 text-primary-800 border-primary-300'
                       : 'bg-gray-50 text-gray-700 border-gray-200 hover:bg-gray-100'
                   }`}
                 >
-                  <option value="">Todas las Razas</option>
-                  {uniqueRazas.map(raza => (
-                    <option key={raza} value={raza}>{raza}</option>
+                  <option value="">Todas las Parcelas/Sitios</option>
+                  {uniqueSitios.map(sitio => (
+                    <option key={sitio} value={sitio}>{sitio}</option>
                   ))}
                 </select>
               </div>
-              
-              {/* Filtro de Estado - Media anchura */}
-              <div className="flex items-center gap-2">
-                <Icon name="heart" className="w-4 h-4 text-gray-600 flex-shrink-0" />
-                <select
-                  value={filters.estado}
-                  onChange={(e) => setFilters({ ...filters, estado: e.target.value })}
-                  className={`flex-1 rounded-xl px-3 py-3 text-base font-medium border-2 transition-colors ${
-                    filters.estado 
-                      ? 'bg-primary-100 text-primary-800 border-primary-300' 
-                      : 'bg-gray-50 text-gray-700 border-gray-200 hover:bg-gray-100'
-                  }`}
-                >
-                  <option value="">Todos</option>
-                  <option value="Disponible">Disponible</option>
-                  <option value="En Monta">En Monta</option>
-                  <option value="Preñada">Preñada</option>
-                  <option value="En Reposo">En Reposo</option>
-                  <option value="Vendido">Vendido</option>
-                  <option value="Fallecido">Fallecido</option>
-                </select>
-              </div>
+
+              {/* Filtros adicionales - Raza y Estado lado a lado cuando se activan */}
+              {showAllFilters && (
+                <div className="grid grid-cols-2 gap-3 animate-in slide-in-from-top duration-200">
+                  {/* Filtro de Razas - Media anchura */}
+                  <div className="flex items-center gap-2">
+                    <Icon name="cow-large" className="w-4 h-4 text-gray-600 flex-shrink-0" />
+                    <select
+                      value={filters.raza}
+                      onChange={(e) => setFilters({ ...filters, raza: e.target.value })}
+                      className={`flex-1 rounded-xl px-3 py-3 text-base font-medium border-2 transition-colors ${
+                        filters.raza
+                          ? 'bg-primary-100 text-primary-800 border-primary-300'
+                          : 'bg-gray-50 text-gray-700 border-gray-200 hover:bg-gray-100'
+                      }`}
+                    >
+                      <option value="">Todas las Razas</option>
+                      {uniqueRazas.map(raza => (
+                        <option key={raza} value={raza}>{raza}</option>
+                      ))}
+                    </select>
+                  </div>
+
+                  {/* Filtro de Estado - Media anchura */}
+                  <div className="flex items-center gap-2">
+                    <Icon name="heart" className="w-4 h-4 text-gray-600 flex-shrink-0" />
+                    <select
+                      value={filters.estado}
+                      onChange={(e) => setFilters({ ...filters, estado: e.target.value })}
+                      className={`flex-1 rounded-xl px-3 py-3 text-base font-medium border-2 transition-colors ${
+                        filters.estado
+                          ? 'bg-primary-100 text-primary-800 border-primary-300'
+                          : 'bg-gray-50 text-gray-700 border-gray-200 hover:bg-gray-100'
+                      }`}
+                    >
+                      <option value="">Todos</option>
+                      <option value="Disponible">Disponible</option>
+                      <option value="En Monta">En Monta</option>
+                      <option value="Preñada">Preñada</option>
+                      <option value="En Reposo">En Reposo</option>
+                      <option value="Vendido">Vendido</option>
+                      <option value="Fallecido">Fallecido</option>
+                    </select>
+                  </div>
+                </div>
+              )}
             </div>
-          )}
-        </div>
-        
-        {/* Botón limpiar filtros */}
-        {(filters.search || filters.sitio || filters.raza || filters.estado) && (
-          <button
-            onClick={() => {
-              setFilters({ search: '', sitio: '', raza: '', estado: '' });
-              setShowAllFilters(false);
-            }}
-            className="w-full flex items-center justify-center gap-2 rounded-xl bg-red-100 text-red-700 hover:bg-red-200 px-4 py-3 text-lg font-medium transition-colors"
-          >
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-            </svg>
-            <span>Limpiar Todos los Filtros</span>
-          </button>
+
+            {/* Botón limpiar filtros */}
+            {(filters.search || filters.sitio || filters.raza || filters.estado) && (
+              <button
+                onClick={() => {
+                  setFilters({ search: '', sitio: '', raza: '', estado: '' });
+                  setShowAllFilters(false);
+                }}
+                className="w-full flex items-center justify-center gap-2 rounded-xl bg-red-100 text-red-700 hover:bg-red-200 px-4 py-3 text-lg font-medium transition-colors"
+              >
+                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                </svg>
+                <span>Limpiar Todos los Filtros</span>
+              </button>
+            )}
+          </div>
         )}
-      </div>
 
       {/* Contador de resultados y ordenamiento */}
-      <div className="px-4 pb-4 flex items-center justify-between">
-        <p className="text-sm text-slate-600">
-          {sortedAndFilteredAnimals.length !== animals.length ? (
-            <>Mostrando {sortedAndFilteredAnimals.length} de {animals.length} animales</>
-          ) : (
-            <>Total: {animals.length} animales</>
-          )}
-        </p>
-        
-        {/* Dropdown de ordenamiento */}
-        <div className="flex items-center gap-2 text-sm">
-          <span className="text-slate-600 font-medium">Ordenar por:</span>
-          <select
-            value={sortBy}
-            onChange={(e) => setSortBy(e.target.value)}
-            className="bg-white border border-slate-200 rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
-          >
-            <option value="arete">Arete</option>
-            <option value="nombre">Nombre</option>
-            <option value="edad">Edad</option>
-            <option value="peso">Peso</option>
-            <option value="raza">Raza</option>
-            <option value="sitio">Sitio</option>
-          </select>
+      {!isKeyboardVisible && (
+        <div className="px-4 pb-4 flex items-center justify-between">
+          <p className="text-sm text-slate-600">
+            {sortedAndFilteredAnimals.length !== animals.length ? (
+              <>Mostrando {sortedAndFilteredAnimals.length} de {animals.length} animales</>
+            ) : (
+              <>Total: {animals.length} animales</>
+            )}
+          </p>
+
+          {/* Dropdown de ordenamiento */}
+          <div className="flex items-center gap-2 text-sm">
+            <span className="text-slate-600 font-medium">Ordenar por:</span>
+            <select
+              value={sortBy}
+              onChange={(e) => setSortBy(e.target.value)}
+              className="bg-white border border-slate-200 rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
+            >
+              <option value="arete">Arete</option>
+              <option value="nombre">Nombre</option>
+              <option value="edad">Edad</option>
+              <option value="peso">Peso</option>
+              <option value="raza">Raza</option>
+              <option value="sitio">Sitio</option>
+            </select>
+          </div>
         </div>
-      </div>
+      )}
 
       {/* Lista de animales estilo cards */}
       <div className="space-y-3 px-4 flex-1 pb-24">

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -24,19 +24,19 @@ export function DashboardPage() {
   return (
     <div className="min-h-screen bg-background">
       {/* Header */}
-      <header className="bg-white shadow-sm border-b border-gray-200">
-        <div className="flex items-center justify-between p-6">
-          <button 
+      <header className="sticky top-0 z-40 bg-white shadow-sm border-b border-gray-200">
+        <div className="flex items-center justify-between px-4 pt-4 pb-2">
+          <button
             onClick={() => setShowMenu(!showMenu)}
-            className="p-4 rounded-xl hover:bg-primary-50 transition-colors min-w-[60px] min-h-[60px] flex items-center justify-center"
+            className="flex h-12 w-12 items-center justify-center rounded-full bg-primary-50 text-primary-700 hover:bg-primary-100 transition-colors shadow-sm"
             aria-label="Abrir menú principal"
           >
-            <svg className="w-8 h-8 text-primary-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg className="w-7 h-7" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M4 6h16M4 12h16M4 18h16" />
             </svg>
           </button>
-          <h1 className="text-2xl font-bold text-primary-800">Inicio</h1>
-          <div className="w-16"></div> {/* Spacer */}
+          <h1 className="flex-1 text-center text-xl font-bold text-slate-900">Inicio</h1>
+          <div className="flex w-12 justify-end" />
         </div>
       </header>
 


### PR DESCRIPTION
## Summary
- update the shared Layout side-menu header to use the sticky Animals page design with centered title and rounded menu button
- add optional headerActions support and adjust page padding so Reproducción, Recordatorios, and Sitios inherit the standardized spacing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dcb1dd25548332be7474b8159dbb32