### PR TITLE
Add SwipeAction showcase demo page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import { ReproductivePage } from './pages/ReproductivePage';
 import { LargeButtonShowcasePage } from './pages/LargeButtonShowcasePage';
 import { CardShowcasePage } from './pages/CardShowcasePage';
 import { InputShowcasePage } from './pages/InputShowcasePage';
+import { SwipeActionShowcasePage } from './pages/SwipeActionShowcasePage';
 // Componente para rutas protegidas
 function ProtectedRoute({ children }: { children: React.ReactNode }) {
   const { usuario, isLoading } = useAuth();
@@ -148,13 +149,22 @@ function App() {
               } 
             />
             {/* Demo de Inputs */}
-            <Route 
-              path="/demo/input" 
+            <Route
+              path="/demo/input"
               element={
                 <ProtectedRoute>
                   <InputShowcasePage />
                 </ProtectedRoute>
-              } 
+              }
+            />
+            {/* Demo de SwipeAction */}
+            <Route
+              path="/demo/swipe-action"
+              element={
+                <ProtectedRoute>
+                  <SwipeActionShowcasePage />
+                </ProtectedRoute>
+              }
             />
             {/* Rutas de reproducción */}
             <Route 

--- a/src/components/common/SwipeAction.md
+++ b/src/components/common/SwipeAction.md
@@ -1,0 +1,66 @@
+# SwipeAction
+
+`SwipeAction` ofrece interacciones de deslizamiento accesibles para listas móviles y un fallback con menú de acciones para dispositivos de escritorio.
+
+## Props
+
+| Prop | Tipo | Default | Descripción |
+|------|------|---------|-------------|
+| `children` | `ReactNode` | - | Contenido principal del elemento (fila de lista, tarjeta compacta, etc.). |
+| `leftActions` | `SwipeActionItem[]` | `[]` | Acciones que aparecen al deslizar hacia la derecha. |
+| `rightActions` | `SwipeActionItem[]` | `[]` | Acciones que aparecen al deslizar hacia la izquierda. |
+| `className` | `string` | `''` | Clases adicionales para personalizar el contenedor. |
+| `actionWidth` | `number` | `88` | Ancho individual (en px) de cada botón de acción revelado por el gesto. |
+| `onOpenChange` | `(side: 'left' \| 'right' \| null) => void` | `undefined` | Callback que notifica el estado abierto del componente. |
+| `moreButtonLabel` | `string` | `'Acciones'` | Etiqueta accesible para el botón de fallback que abre el menú contextual. |
+
+### SwipeActionItem
+
+| Prop | Tipo | Default | Descripción |
+|------|------|---------|-------------|
+| `id` | `string` | - | Identificador estable para la acción. |
+| `label` | `string` | - | Texto mostrado y anunciado por lectores de pantalla. |
+| `onPress` | `() => void` | - | Callback ejecutado al activar la acción. |
+| `icon` | `ReactNode` | `undefined` | Icono opcional mostrado antes del texto. |
+| `ariaLabel` | `string` | `label` | Etiqueta accesible alternativa si el texto visual necesita contexto extra. |
+| `intent` | `'default' \| 'edit' \| 'delete'` | `'default'` | Define el color temático del botón (verde, azul, rojo). |
+| `className` | `string` | `undefined` | Permite extender estilos Tailwind para acciones puntuales. |
+
+## Uso Básico
+
+```tsx
+import { SwipeAction } from '@/components/common';
+import { PencilSimple, Trash } from '@phosphor-icons/react';
+
+<SwipeAction
+  leftActions={[{
+    id: 'edit',
+    label: 'Editar',
+    intent: 'edit',
+    icon: <PencilSimple weight="bold" />,
+    onPress: () => navigate(`/animals/${animal.id}/edit`)
+  }]}
+  rightActions={[{
+    id: 'delete',
+    label: 'Eliminar',
+    intent: 'delete',
+    icon: <Trash weight="bold" />,
+    onPress: () => deleteAnimal(animal.id)
+  }]}
+>
+  <article className="flex items-center justify-between px-4 py-5">
+    <div>
+      <p className="text-xl font-semibold text-primary-900">{animal.name}</p>
+      <p className="text-base text-primary-600">#{animal.tag}</p>
+    </div>
+    <span className="text-base font-medium text-primary-700">{animal.weight} kg</span>
+  </article>
+</SwipeAction>
+```
+
+## Accesibilidad
+
+- El contenido principal es enfocable (`tabIndex=0`) y soporta **ArrowLeft/ArrowRight** para mostrar acciones y **Escape** para cerrarlas.
+- El botón flotante "Acciones" queda oculto visualmente hasta hover/focus, pero siempre es alcanzable por teclado y anuncia un menú con todas las opciones disponibles.
+- Cada acción renderiza un botón nativo con mínimo táctil de 44px y contraste adaptado al intent seleccionado.
+- El componente cierra el estado abierto al hacer tap/click fuera, al activar una acción o al presionar **Escape**.

--- a/src/components/common/SwipeAction.tsx
+++ b/src/components/common/SwipeAction.tsx
@@ -1,0 +1,346 @@
+import type { CSSProperties, ReactNode } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+const ACTION_WIDTH = 88;
+const ANIMATION_DURATION = 280;
+
+type SwipeSide = 'left' | 'right' | null;
+
+type SwipeActionIntent = 'default' | 'edit' | 'delete';
+
+export interface SwipeActionItem {
+  id: string;
+  label: string;
+  onPress: () => void;
+  icon?: ReactNode;
+  ariaLabel?: string;
+  intent?: SwipeActionIntent;
+  className?: string;
+}
+
+export interface SwipeActionProps {
+  children: ReactNode;
+  leftActions?: SwipeActionItem[];
+  rightActions?: SwipeActionItem[];
+  className?: string;
+  actionWidth?: number;
+  onOpenChange?: (side: SwipeSide) => void;
+  moreButtonLabel?: string;
+}
+
+const intentClasses: Record<SwipeActionIntent, string> = {
+  default: 'bg-primary-600 hover:bg-primary-700 text-white',
+  edit: 'bg-blue-600 hover:bg-blue-700 text-white',
+  delete: 'bg-red-600 hover:bg-red-700 text-white'
+};
+
+function getActionClasses(intent: SwipeActionIntent, custom?: string) {
+  const baseClasses = 'flex items-center justify-center gap-2 px-4 text-base font-semibold min-w-[72px] min-h-[44px] '
+    + 'focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-white/80 text-white';
+
+  return [baseClasses, intentClasses[intent], custom].filter(Boolean).join(' ');
+}
+
+export function SwipeAction({
+  children,
+  leftActions = [],
+  rightActions = [],
+  className = '',
+  actionWidth = ACTION_WIDTH,
+  onOpenChange,
+  moreButtonLabel = 'Acciones'
+}: SwipeActionProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [translate, setTranslate] = useState(0);
+  const translateRef = useRef(0);
+  const [isDragging, setIsDragging] = useState(false);
+  const [openSide, setOpenSide] = useState<SwipeSide>(null);
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const startXRef = useRef(0);
+  const startTranslateRef = useRef(0);
+  const isDraggingRef = useRef(false);
+
+  const totalLeftWidth = useMemo(() => leftActions.length * actionWidth, [leftActions, actionWidth]);
+  const totalRightWidth = useMemo(() => rightActions.length * actionWidth, [rightActions, actionWidth]);
+
+  const clampTranslate = useCallback((value: number) => {
+    const min = -totalRightWidth;
+    const max = totalLeftWidth;
+
+    if (value < min) {
+      return min;
+    }
+
+    if (value > max) {
+      return max;
+    }
+
+    return value;
+  }, [totalLeftWidth, totalRightWidth]);
+
+  const setSide = useCallback((side: SwipeSide) => {
+    setOpenSide(side);
+
+    const nextTranslate = side === 'left'
+      ? totalLeftWidth
+      : side === 'right'
+        ? -totalRightWidth
+        : 0;
+
+    translateRef.current = nextTranslate;
+    setTranslate(nextTranslate);
+    setIsMenuOpen(false);
+
+    if (onOpenChange) {
+      onOpenChange(side);
+    }
+  }, [onOpenChange, totalLeftWidth, totalRightWidth]);
+
+  const close = useCallback(() => {
+    setSide(null);
+  }, [setSide]);
+
+  const handlePointerDown = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    if (event.pointerType === 'mouse' && event.buttons !== 1) {
+      return;
+    }
+
+    setIsDragging(true);
+    isDraggingRef.current = true;
+    startXRef.current = event.clientX;
+    startTranslateRef.current = translateRef.current;
+
+    event.currentTarget.setPointerCapture?.(event.pointerId);
+  }, []);
+
+  const finishGesture = useCallback((currentTranslate: number) => {
+    const hasLeft = totalLeftWidth > 0;
+    const hasRight = totalRightWidth > 0;
+
+    if (currentTranslate > 0 && hasLeft) {
+      if (currentTranslate >= totalLeftWidth * 0.5) {
+        setSide('left');
+        return;
+      }
+    }
+
+    if (currentTranslate < 0 && hasRight) {
+      if (Math.abs(currentTranslate) >= totalRightWidth * 0.5) {
+        setSide('right');
+        return;
+      }
+    }
+
+    close();
+  }, [close, setSide, totalLeftWidth, totalRightWidth]);
+
+  const handlePointerMove = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    if (!isDraggingRef.current) {
+      return;
+    }
+
+    const delta = event.clientX - startXRef.current;
+    const nextTranslate = clampTranslate(startTranslateRef.current + delta);
+
+    if (Math.abs(delta) > 8) {
+      event.preventDefault();
+    }
+
+    translateRef.current = nextTranslate;
+    setTranslate(nextTranslate);
+  }, [clampTranslate]);
+
+  const handlePointerEnd = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    if (!isDraggingRef.current) {
+      return;
+    }
+
+    event.currentTarget.releasePointerCapture?.(event.pointerId);
+    setIsDragging(false);
+    isDraggingRef.current = false;
+    finishGesture(clampTranslate(translateRef.current));
+  }, [clampTranslate, finishGesture, translateRef]);
+
+  const handlePointerLeave = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    if (!isDraggingRef.current) {
+      return;
+    }
+
+    handlePointerEnd(event);
+  }, [handlePointerEnd]);
+
+  const handleKeyDown = useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'ArrowLeft' && leftActions.length > 0) {
+      event.preventDefault();
+      setSide('left');
+      return;
+    }
+
+    if (event.key === 'ArrowRight' && rightActions.length > 0) {
+      event.preventDefault();
+      setSide('right');
+      return;
+    }
+
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      close();
+    }
+  }, [close, leftActions.length, rightActions.length, setSide]);
+
+  useEffect(() => {
+    if (!openSide && !isMenuOpen) {
+      return;
+    }
+
+    const handlePointerDownOutside = (event: PointerEvent) => {
+      if (!containerRef.current) {
+        return;
+      }
+
+      const target = event.target as Node | null;
+
+      if (target && !containerRef.current.contains(target)) {
+        close();
+        setIsMenuOpen(false);
+      }
+    };
+
+    document.addEventListener('pointerdown', handlePointerDownOutside);
+
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDownOutside);
+    };
+  }, [close, isMenuOpen, openSide]);
+
+  useEffect(() => {
+    if (!isMenuOpen) {
+      return;
+    }
+
+    const handleKeyDownOutside = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        setIsMenuOpen(false);
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDownOutside);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDownOutside);
+    };
+  }, [isMenuOpen]);
+
+  const actionStyle: CSSProperties = useMemo(() => ({ width: `${actionWidth}px` }), [actionWidth]);
+
+  const contentStyle: CSSProperties = useMemo(() => ({
+    transform: `translateX(${translate}px)`,
+    transition: isDragging ? 'none' : `transform ${ANIMATION_DURATION}ms ease`,
+    touchAction: 'pan-y'
+  }), [isDragging, translate]);
+
+  const renderAction = useCallback((action: SwipeActionItem) => {
+    const intent = action.intent ?? 'default';
+    const ariaLabel = action.ariaLabel ?? action.label;
+
+    return (
+      <button
+        key={action.id}
+        type="button"
+        className={getActionClasses(intent, action.className)}
+        style={actionStyle}
+        onClick={() => {
+          action.onPress();
+          close();
+        }}
+        aria-label={ariaLabel}
+      >
+        {action.icon ? (
+          <span aria-hidden className="text-xl">
+            {action.icon}
+          </span>
+        ) : null}
+        <span>{action.label}</span>
+      </button>
+    );
+  }, [actionStyle, close]);
+
+  return (
+    <div
+      ref={containerRef}
+      className={`group relative overflow-hidden rounded-2xl bg-white shadow-sm focus-within:ring-2 focus-within:ring-primary-400 ${className}`.trim()}
+      data-component="swipe-action"
+      data-open-side={openSide ?? ''}
+    >
+      <div className="absolute inset-y-0 left-0 flex" aria-hidden={leftActions.length === 0}>
+        {leftActions.map(renderAction)}
+      </div>
+
+      <div className="absolute inset-y-0 right-0 flex" aria-hidden={rightActions.length === 0}>
+        {rightActions.map(renderAction)}
+      </div>
+
+      <div
+        role="group"
+        aria-roledescription="Swipeable item"
+        tabIndex={0}
+        data-slot="content"
+        className="relative z-10 cursor-pointer select-none"
+        style={contentStyle}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerEnd}
+        onPointerCancel={handlePointerEnd}
+        onPointerLeave={handlePointerLeave}
+        onKeyDown={handleKeyDown}
+      >
+        {children}
+      </div>
+
+      {(leftActions.length > 0 || rightActions.length > 0) && (
+        <div className="pointer-events-none absolute right-3 top-3 z-20 flex flex-col items-end gap-2">
+          <button
+            type="button"
+            className="pointer-events-auto inline-flex h-11 w-11 items-center justify-center rounded-full bg-primary-600 text-white opacity-0 transition-opacity duration-200 focus:outline-none focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-primary-500 group-hover:opacity-100"
+            aria-label={moreButtonLabel}
+            title={moreButtonLabel}
+            aria-haspopup="menu"
+            aria-expanded={isMenuOpen}
+            onClick={() => setIsMenuOpen((value) => !value)}
+          >
+            <span aria-hidden className="text-2xl">⋮</span>
+          </button>
+
+          {isMenuOpen && (
+            <div
+              role="menu"
+              className="pointer-events-auto mt-2 flex min-w-[180px] flex-col gap-1 rounded-xl bg-white p-2 shadow-lg ring-1 ring-black/5"
+            >
+              {[...leftActions, ...rightActions].map((action) => (
+                <button
+                  key={`menu-${action.id}`}
+                  type="button"
+                  role="menuitem"
+                  className="flex items-center gap-3 rounded-lg px-3 py-2 text-left text-base font-medium text-primary-900 hover:bg-primary-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
+                  onClick={() => {
+                    action.onPress();
+                    setIsMenuOpen(false);
+                    close();
+                  }}
+                >
+                  {action.icon ? (
+                    <span aria-hidden className="text-xl text-primary-700">
+                      {action.icon}
+                    </span>
+                  ) : null}
+                  <span>{action.label}</span>
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/common/__tests__/SwipeAction.test.tsx
+++ b/src/components/common/__tests__/SwipeAction.test.tsx
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SwipeAction } from '../SwipeAction';
+
+describe('SwipeAction', () => {
+  it('reveals right actions and triggers action handlers', async () => {
+    const onDelete = vi.fn();
+    const onOpenChange = vi.fn();
+
+    const { container } = render(
+      <SwipeAction
+        rightActions={[{
+          id: 'delete',
+          label: 'Eliminar',
+          intent: 'delete',
+          onPress: onDelete
+        }]}
+        onOpenChange={onOpenChange}
+      >
+        <div className="p-4">Registro #1</div>
+      </SwipeAction>
+    );
+
+    const root = container.querySelector('[data-component="swipe-action"]') as HTMLElement;
+    const content = root.querySelector('[data-slot="content"]') as HTMLElement;
+
+    content.focus();
+    fireEvent.keyDown(content, { key: 'ArrowRight' });
+
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith('right'));
+    expect(root.dataset.openSide).toBe('right');
+
+    const deleteButton = screen.getByRole('button', { name: 'Eliminar' });
+    fireEvent.click(deleteButton);
+
+    expect(onDelete).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(onOpenChange).toHaveBeenLastCalledWith(null));
+    expect(root.dataset.openSide).toBe('');
+  });
+
+  it('opens fallback menu via button and executes selected action', async () => {
+    const onEdit = vi.fn();
+    const onDelete = vi.fn();
+
+    render(
+      <SwipeAction
+        leftActions={[{
+          id: 'edit',
+          label: 'Editar',
+          intent: 'edit',
+          onPress: onEdit
+        }]}
+        rightActions={[{
+          id: 'delete',
+          label: 'Eliminar',
+          intent: 'delete',
+          onPress: onDelete
+        }]}
+      >
+        <div className="p-4">Acción</div>
+      </SwipeAction>
+    );
+
+    const user = userEvent.setup();
+    const fallbackButton = screen.getByRole('button', { name: 'Acciones' });
+
+    await user.click(fallbackButton);
+
+    const editFromMenu = screen.getByRole('menuitem', { name: 'Editar' });
+    await user.click(editFromMenu);
+
+    expect(onEdit).toHaveBeenCalledTimes(1);
+    expect(onDelete).not.toHaveBeenCalled();
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+  });
+
+  it('supports keyboard navigation to open and close swipe states', () => {
+    const onOpenChange = vi.fn();
+
+    const { container } = render(
+      <SwipeAction
+        leftActions={[{
+          id: 'edit',
+          label: 'Editar',
+          intent: 'edit',
+          onPress: vi.fn()
+        }]}
+        rightActions={[{
+          id: 'delete',
+          label: 'Eliminar',
+          intent: 'delete',
+          onPress: vi.fn()
+        }]}
+        onOpenChange={onOpenChange}
+      >
+        <div className="p-4">Elemento</div>
+      </SwipeAction>
+    );
+
+    const root = container.querySelector('[data-component="swipe-action"]') as HTMLElement;
+    const content = root.querySelector('[data-slot="content"]') as HTMLElement;
+
+    content.focus();
+    fireEvent.keyDown(content, { key: 'ArrowLeft' });
+
+    expect(root.dataset.openSide).toBe('left');
+
+    fireEvent.keyDown(content, { key: 'Escape' });
+
+    expect(root.dataset.openSide).toBe('');
+    expect(onOpenChange).toHaveBeenCalledWith('left');
+    expect(onOpenChange).toHaveBeenCalledWith(null);
+  });
+});

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -3,3 +3,5 @@ export { LargeButton } from './LargeButton';
 export type { LargeButtonProps } from './LargeButton';
 export { Card } from './Card';
 export type { CardProps, CardVariant } from './Card';
+export { SwipeAction } from './SwipeAction';
+export type { SwipeActionProps, SwipeActionItem } from './SwipeAction';

--- a/src/pages/SwipeActionShowcasePage.tsx
+++ b/src/pages/SwipeActionShowcasePage.tsx
@@ -1,0 +1,263 @@
+import { useMemo, useState } from 'react';
+import {
+  CalendarDays,
+  ClipboardList,
+  Edit3,
+  Flag,
+  MessageCircle,
+  ShieldAlert,
+  Trash2,
+} from 'lucide-react';
+import { SwipeAction, type SwipeActionItem } from '../components/common';
+
+interface ReminderItem {
+  id: string;
+  title: string;
+  description: string;
+  status: 'pendiente' | 'programado' | 'atendido';
+  scheduledFor: string;
+}
+
+const reminderItems: ReminderItem[] = [
+  {
+    id: 'r1',
+    title: 'Revisión veterinaria',
+    description: 'Chequeo clínico para #A-102 (Vaca Holstein)',
+    status: 'pendiente',
+    scheduledFor: 'Hoy 15:30',
+  },
+  {
+    id: 'r2',
+    title: 'Vacunación aftosa',
+    description: 'Aplicar lote 2024-A al hato joven',
+    status: 'programado',
+    scheduledFor: 'Mañana 09:00',
+  },
+  {
+    id: 'r3',
+    title: 'Registro de parto',
+    description: 'Capturar datos recién nacidos del lote 12',
+    status: 'atendido',
+    scheduledFor: 'Ayer 18:45',
+  },
+];
+
+const statusStyles: Record<ReminderItem['status'], string> = {
+  pendiente: 'bg-orange-100 text-orange-700 border-orange-200',
+  programado: 'bg-blue-100 text-blue-700 border-blue-200',
+  atendido: 'bg-emerald-100 text-emerald-700 border-emerald-200',
+};
+
+export function SwipeActionShowcasePage() {
+  const [log, setLog] = useState<string[]>(['Interactúa con las filas para ver las acciones ejecutadas.']);
+  const [openedId, setOpenedId] = useState<string | null>(null);
+
+  const logAction = (message: string) => {
+    setLog((current) => [message, ...current].slice(0, 5));
+  };
+
+  const createLeftActions = (item: ReminderItem): SwipeActionItem[] => [
+    {
+      id: `${item.id}-edit`,
+      label: 'Editar',
+      intent: 'edit',
+      icon: <Edit3 className="h-5 w-5" aria-hidden="true" />,
+      onPress: () => {
+        logAction(`Editar programado para "${item.title}".`);
+      },
+    },
+    {
+      id: `${item.id}-note`,
+      label: 'Anotar',
+      icon: <ClipboardList className="h-5 w-5" aria-hidden="true" />,
+      onPress: () => {
+        logAction(`Se añadió una nota rápida a "${item.title}".`);
+      },
+    },
+  ];
+
+  const createRightActions = (item: ReminderItem): SwipeActionItem[] => {
+    const right: SwipeActionItem[] = [
+      {
+        id: `${item.id}-flag`,
+        label: 'Priorizar',
+        icon: <Flag className="h-5 w-5" aria-hidden="true" />,
+        onPress: () => {
+          logAction(`"${item.title}" marcado como prioritario.`);
+        },
+      },
+      {
+        id: `${item.id}-delete`,
+        label: 'Eliminar',
+        intent: 'delete',
+        icon: <Trash2 className="h-5 w-5" aria-hidden="true" />,
+        onPress: () => {
+          logAction(`Recordatorio eliminado: "${item.title}".`);
+        },
+      },
+    ];
+
+    if (item.status !== 'atendido') {
+      right.unshift({
+        id: `${item.id}-done`,
+        label: 'Completar',
+        icon: <ShieldAlert className="h-5 w-5" aria-hidden="true" />,
+        onPress: () => {
+          logAction(`"${item.title}" se marcó como atendido.`);
+        },
+      });
+    }
+
+    return right;
+  };
+
+  const actionSummary = useMemo(() => {
+    if (!openedId) {
+      return 'Ninguna fila abierta.';
+    }
+
+    const item = reminderItems.find(({ id }) => id === openedId);
+    if (!item) {
+      return 'Fila cerrada.';
+    }
+
+    return `Acciones visibles para "${item.title}".`;
+  }, [openedId]);
+
+  return (
+    <div className="min-h-screen bg-background-light py-10 px-6">
+      <div className="mx-auto flex max-w-5xl flex-col gap-8">
+        <header className="space-y-4">
+          <p className="text-sm font-semibold uppercase tracking-wide text-primary-600">Demo</p>
+          <h1 className="text-4xl font-bold text-gray-900">Swipe Action Playground</h1>
+          <p className="max-w-3xl text-lg text-gray-600">
+            Practica los gestos de deslizamiento, la navegación por teclado y el menú contextual del componente
+            <code className="mx-1 rounded bg-gray-100 px-1">SwipeAction</code>. Ideal para validar combinaciones de
+            acciones antes de integrarlo en listados reales.
+          </p>
+        </header>
+
+        <section className="rounded-2xl bg-white p-8 shadow-sm">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+            <div>
+              <h2 className="text-2xl font-semibold text-gray-900">Recordatorios interactivos</h2>
+              <p className="text-sm text-gray-600">
+                Desliza hacia los lados o usa <kbd className="rounded border border-gray-300 px-1">←</kbd>
+                <kbd className="ml-1 rounded border border-gray-300 px-1">→</kbd> sobre cada fila para descubrir las
+                acciones. Presiona <kbd className="ml-1 rounded border border-gray-300 px-1">Esc</kbd> para cerrar.
+              </p>
+            </div>
+            <div className="rounded-xl border border-primary-100 bg-primary-50/70 px-4 py-3 text-sm text-primary-900">
+              {actionSummary}
+            </div>
+          </div>
+
+          <div className="mt-6 divide-y divide-gray-200 rounded-xl border border-gray-200 bg-gray-50">
+            {reminderItems.map((item) => (
+              <SwipeAction
+                key={item.id}
+                className="bg-white"
+                leftActions={createLeftActions(item)}
+                rightActions={createRightActions(item)}
+                onOpenChange={(side) => {
+                  setOpenedId(side ? item.id : null);
+                }}
+              >
+                <article className="flex items-center gap-4 px-5 py-4">
+                  <div className="flex h-11 w-11 items-center justify-center rounded-full bg-primary-100 text-primary-700">
+                    <CalendarDays className="h-6 w-6" aria-hidden="true" />
+                  </div>
+                  <div className="flex-1 space-y-1">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <h3 className="text-lg font-semibold text-gray-900">{item.title}</h3>
+                      <span className={`rounded-full border px-2.5 py-1 text-xs font-semibold ${statusStyles[item.status]}`}>
+                        {item.status}
+                      </span>
+                    </div>
+                    <p className="text-sm text-gray-600">{item.description}</p>
+                    <p className="text-xs font-medium text-primary-700">{item.scheduledFor}</p>
+                  </div>
+                  <button
+                    type="button"
+                    className="inline-flex items-center gap-2 rounded-full border border-primary-200 bg-white px-3 py-1 text-sm font-medium text-primary-700 shadow-sm transition hover:bg-primary-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2"
+                    onClick={() => logAction(`Se envió mensaje interno sobre "${item.title}".`)}
+                  >
+                    <MessageCircle className="h-4 w-4" aria-hidden="true" />
+                    Mensaje
+                  </button>
+                </article>
+              </SwipeAction>
+            ))}
+          </div>
+        </section>
+
+        <section className="grid gap-6 lg:grid-cols-2">
+          <div className="rounded-2xl bg-white p-8 shadow-sm">
+            <h2 className="text-2xl font-semibold text-gray-900">Fallback para escritorio</h2>
+            <p className="text-sm text-gray-600">
+              En pantallas grandes, el botón flotante "Acciones" ofrece un menú contextual accesible con todas las opciones
+              disponibles. Interactúa con teclado o mouse para probarlo.
+            </p>
+            <div className="mt-4 space-y-3">
+              <SwipeAction
+                className="bg-white"
+                rightActions={[
+                  {
+                    id: 'draft-edit',
+                    label: 'Editar borrador',
+                    intent: 'edit',
+                    icon: <Edit3 className="h-5 w-5" aria-hidden="true" />,
+                    onPress: () => logAction('Se abrió la edición del borrador.'),
+                  },
+                  {
+                    id: 'draft-delete',
+                    label: 'Descartar',
+                    intent: 'delete',
+                    icon: <Trash2 className="h-5 w-5" aria-hidden="true" />,
+                    onPress: () => logAction('Borrador descartado.'),
+                  },
+                ]}
+                leftActions={[
+                  {
+                    id: 'draft-share',
+                    label: 'Compartir',
+                    icon: <MessageCircle className="h-5 w-5" aria-hidden="true" />,
+                    onPress: () => logAction('Se compartió el borrador por mensaje.'),
+                  },
+                ]}
+                moreButtonLabel="Ver acciones del borrador"
+              >
+                <article className="rounded-xl border border-dashed border-primary-200 bg-primary-50/70 px-5 py-6">
+                  <h3 className="text-lg font-semibold text-primary-900">Plantilla de checklist diaria</h3>
+                  <p className="mt-2 text-sm text-primary-700">
+                    Esta sección demuestra el botón "Acciones" que aparece al pasar el mouse o enfocar el elemento con teclado.
+                  </p>
+                </article>
+              </SwipeAction>
+            </div>
+          </div>
+
+          <div className="rounded-2xl bg-white p-8 shadow-sm">
+            <h2 className="text-2xl font-semibold text-gray-900">Registro de interacción</h2>
+            <p className="text-sm text-gray-600">
+              Se listan las últimas acciones ejecutadas para validar la integración con callbacks reales.
+            </p>
+            <ul className="mt-4 space-y-2">
+              {log.map((entry, index) => (
+                <li
+                  key={`${entry}-${index}`}
+                  className="flex items-start gap-2 rounded-lg bg-gray-50 px-3 py-2 text-sm text-gray-700"
+                >
+                  <span className="mt-1 inline-flex h-2.5 w-2.5 flex-none rounded-full bg-primary-500" aria-hidden="true" />
+                  {entry}
+                </li>
+              ))}
+            </ul>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}
+
+export default SwipeActionShowcasePage;


### PR DESCRIPTION
## Summary
- add a SwipeAction playground page with sample reminder rows, fallback menu demo, and interaction log
- register the new demo route inside the protected area so it can be accessed alongside other component showcases

## Testing
- npm test -- SwipeAction.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e13bb527a48332a7acb65c7043a708